### PR TITLE
Fixed some problems that pop up with gcc.

### DIFF
--- a/tapescript/cpp/cl/tape/examples/impl/array_examples.hpp
+++ b/tapescript/cpp/cl/tape/examples/impl/array_examples.hpp
@@ -25,7 +25,7 @@ limitations under the License.
 
 #define CL_BASE_SERIALIZER_OPEN
 #include <cl/tape/tape.hpp>
-#include "impl/utils.hpp"
+#include "utils.hpp"
 
 namespace cl
 {

--- a/tapescript/cpp/cl/tape/examples/impl/double_examples.hpp
+++ b/tapescript/cpp/cl/tape/examples/impl/double_examples.hpp
@@ -25,7 +25,7 @@ limitations under the License.
 
 #define CL_BASE_SERIALIZER_OPEN
 #include <cl/tape/tape.hpp>
-#include "impl/array_examples.hpp"
+#include "array_examples.hpp"
 
 
 namespace cl

--- a/tapescript/cpp/cl/tape/examples/impl/performance_tests.hpp
+++ b/tapescript/cpp/cl/tape/examples/impl/performance_tests.hpp
@@ -23,7 +23,7 @@ limitations under the License.
 #ifndef cl_tape_examples_impl_performance_tests_hpp
 #define cl_tape_examples_impl_performance_tests_hpp
 
-#include "impl/performance_utils.hpp"
+#include "performance_utils.hpp"
 
 namespace cl
 {

--- a/tapescript/cpp/cl/tape/examples/impl/performance_utils.hpp
+++ b/tapescript/cpp/cl/tape/examples/impl/performance_utils.hpp
@@ -31,7 +31,7 @@ limitations under the License.
 #include <cl/tape/tape.hpp>
 #include <cl/tape/util/testoutput.hpp>
 
-#include "impl/utils.hpp"
+#include "utils.hpp"
 
 namespace cl
 {

--- a/tapescript/cpp/cl/tape/examples/tape_example.cpp
+++ b/tapescript/cpp/cl/tape/examples/tape_example.cpp
@@ -27,7 +27,7 @@ limitations under the License.
 
 #include <cl/tape/tape.hpp>
 
-#include "impl\utils.hpp"
+#include "impl/utils.hpp"
 
 struct test_stream
 {

--- a/tapescript/cpp/cl/tape/tape.hpp
+++ b/tapescript/cpp/cl/tape/tape.hpp
@@ -50,7 +50,7 @@ namespace cl
 // Lock undef include
 #define CPPAD_UNDEF_INCLUDED
 
-#include <cppad/cppad.h>
+#include <cppad/cppad.hpp>
 
 #if !defined CL_USE_NATIVE_FORWARD
 #   if !defined TYPE_SERIALIZER
@@ -113,7 +113,7 @@ namespace cl
 namespace ext
 {
     template <typename Type>
-    inline typename Type Value(Type const& v)
+    inline Type Value(Type const& v)
     {   return v; }
 }
 #endif


### PR DESCRIPTION
Hi Team,

I try to compile tape_example.cpp sitting in ~/tapescript/tapescript/cpp/cl/tape/examples/ on my Linux machine with

g++ -I ~/tapescript/dependencies/cpp/ -I ~/tapescript/tapescript/cpp/ tape_example.cpp -o tape_example -std=c++11

(I am using gcc 5.1.0), this doesn't work, it throws a lot of error messages. This PR fixes a few obvious problems, still I am not able to compile the example.

It would be great if you could have a look and assist please ? Are the compiler options correct for example or is anything missing there ?

Thanks
Peter
